### PR TITLE
ローカル環境と本番環境のmysql設定の統一 (database.yml)

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -50,5 +50,6 @@ test:
 production:
   <<: *default
   database: mercari_production
-  username: mercari
-  password: <%= ENV['MERCARI_DATABASE_PASSWORD'] %>
+  username: root
+  password: <%= ENV['DATABASE_PASSWORD'] %>
+  socket: /var/lib/mysql/mysql.sock


### PR DESCRIPTION
# why
ローカル環境と本番環境のmysqlの設定が違うと、mysqlへ接続できなくなっているため

# what
本番環境でmysqlへ接続できないので本番環境のmysqlをローカル環境と統一するように設定を修正