### PR TITLE
unicornを再起動した際に変更した環境変数を読み込むように修正(config/unicorn.rb)

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -28,7 +28,9 @@ set :keep_releases, 5
 after 'deploy:publishing', 'deploy:restart'
 namespace :deploy do
   task :restart do
-    invoke 'unicorn:restart'
+    # invoke 'unicorn:restart'
+    invoke 'unicorn:stop'
+    invoke 'unicorn:start'
   end
 end
 


### PR DESCRIPTION
# What
「unicorn:restart」と記述していたが、「unicorn:stop」「unicorn:start」という記述にして、unicornを再起動した際に意図的にunicornをストップしてアプリのサーバーを一旦落とし、環境変数の変更が読み込まれるようにコードを修正した

# Why
本番環境の環境変数を変更や追加した際に、それらの変更がunicornを再起動した際に読み込まれるようにするため
「unicorn:restart」の記述では、環境変数の変更が読み込まれないため。