### PR TITLE
商品詳細ページから商品購入ページに遷移する際にmasterでエラーが発生したため修正

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,6 +1,6 @@
 class ProductsController < ApplicationController
   require 'payjp'
-  before_action :find_product, only: [:show, :destroy]
+  before_action :set_product, only: [:show, :destroy]
 
   def index
     require 'base64'
@@ -161,7 +161,7 @@ class ProductsController < ApplicationController
     params.require(:registered_images_ids).permit({ids: []})
   end
 
-  def find_product
+  def set_product
     @product = Product.find(params[:id])
   end
 

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,6 +1,6 @@
 class ProductsController < ApplicationController
   require 'payjp'
-  before_action :find_product, only: [:show, :destroy, :product_confirmation, :product_pay, :product_done]
+  before_action :find_product, only: [:show, :destroy]
 
   def index
     require 'base64'
@@ -93,6 +93,7 @@ class ProductsController < ApplicationController
   end
   
   def product_confirmation
+    @product = Product.find(params[:product_id])
     @user = current_user
     @address = @user.address
     # テーブルからpayjpの顧客IDを検索
@@ -114,6 +115,7 @@ class ProductsController < ApplicationController
   end
 
   def product_pay
+    @product = Product.find(params[:product_id])
     card = Credit.where(user_id: current_user.id).first
     Payjp.api_key = Rails.application.credentials[:payjp][:PAYJP_SECRET_KEY]
     Payjp::Charge.create(
@@ -125,6 +127,7 @@ class ProductsController < ApplicationController
   end
 
   def product_done
+     @product = Product.find(params[:product_id])
   end
 
   def creare

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -153,7 +153,7 @@
       %span.products-show__product-details__price__text= number_to_currency(@product.price, :format => "%u%n", :unit => "￥")
       %span.products-show__product-details__price__tax （税込）
       %span.products-show__product-details__price__postage 送料込み
-    = link_to product_product_confirmation_path, class: "products-show__product-details__btn" do
+    = link_to product_product_confirmation_path(params[:id]), class: "products-show__product-details__btn" do
       購入画面に進む
     .products-show__product-details__text
       %p.products-show__product-details__text__inner


### PR DESCRIPTION
# Why
ユーザーが購入したい商品を購入できるようにするため

# What
ユーザーが選択した商品のidを次のページに持ってきた上で、その商品を登録したクレジットカードで購入できるように変更