### PR TITLE
ユーザーがログインしていない場合、ログインページにリダイレクトさせる

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,5 +1,6 @@
 class ProductsController < ApplicationController
   require 'payjp'
+  before_action :redirect_login, except: [:index, :show]
   before_action :set_product, only: [:show, :destroy]
 
   def index
@@ -176,6 +177,10 @@ class ProductsController < ApplicationController
   end
   
   def privacy_policy
+  end
+
+  def redirect_login
+    redirect_to new_user_session_path unless user_signed_in?
   end
 
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -7,8 +7,13 @@ class UsersController < ApplicationController
   before_action :validates_step3, only: :step4
   before_action :validates_step4, only: :step6
   before_action :validates_step6, only: :step7
+  before_action :redirect_login, except: [:index, :show]
+
   
   layout "users_layout"
+
+  def index
+  end
   
   def show
     redirect_to "/"
@@ -209,7 +214,7 @@ class UsersController < ApplicationController
         :last_name,
         :first_name,
         :last_name_kana,
-        :first_name_kana,        
+        :first_name_kana,
         :postal_code,
         :address_prefecture,
         :address_city,
@@ -218,5 +223,9 @@ class UsersController < ApplicationController
         :address_phone,
       ]
     )
+  end
+
+  def redirect_login
+    redirect_to new_user_session_path unless user_signed_in?
   end
 end


### PR DESCRIPTION
# Why
URLを直打ちした場合、ログインしていない場合でも飛べるページがあるため、
ログインしないと本来入れないページに飛んだ際にログインページにリダイレクトさせる必要があるため

# What
ログインしていない場合は、商品一覧と商品詳細ページ以外のページに飛ぶとログインページに飛ぶようにリダイレクトを記述